### PR TITLE
Support indexing of worktrees (vibe-kanban)

### DIFF
--- a/pkg/repoindex/repo-index.go
+++ b/pkg/repoindex/repo-index.go
@@ -76,9 +76,10 @@ func BuildRepoIndex() error {
 		return fmt.Errorf("error getting repository roots: %v", err)
 	}
 
+	processedRemotes := make(map[string]struct{})
 	var repos []RepoData
 	for _, rootLocation := range roots {
-		reposFromRoot := locateRepos(rootLocation)
+		reposFromRoot := locateRepos(rootLocation, processedRemotes)
 		repos = append(repos, reposFromRoot...)
 	}
 
@@ -89,10 +90,10 @@ func BuildRepoIndex() error {
 	return nil
 }
 
-func locateRepos(rootLocation string) []RepoData {
+func locateRepos(rootLocation string, processedRemotes map[string]struct{}) []RepoData {
 	var repos []RepoData
 
-	err := filepath.Walk(rootLocation, visit(rootLocation, &repos))
+	err := filepath.Walk(rootLocation, visit(rootLocation, &repos, processedRemotes))
 	if err != nil {
 		fmt.Printf("Error walking the path %v: %v\n", rootLocation, err)
 	}
@@ -102,7 +103,7 @@ func locateRepos(rootLocation string) []RepoData {
 	return repos
 }
 
-func visit(rootLocation string, paths *[]RepoData) filepath.WalkFunc {
+func visit(rootLocation string, paths *[]RepoData, processedRemotes map[string]struct{}) filepath.WalkFunc {
 	return func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			fmt.Println(err) // can't walk here,
@@ -123,6 +124,29 @@ func visit(rootLocation string, paths *[]RepoData) filepath.WalkFunc {
 					repoType := repoType(gitHttpUrl)
 					repoData := RepoData{BaseDir: repoDir, FullName: repoName, Url: gitHttpUrl, Type: repoType}
 					*paths = append(*paths, repoData)
+
+					if _, ok := processedRemotes[remoteURL]; !ok {
+						processedRemotes[remoteURL] = struct{}{}
+						worktrees, err := getWorktrees(path)
+						if err == nil {
+							for _, wtPath := range worktrees {
+								if wtPath == path {
+									continue
+								}
+
+								// Check if inside rootLocation
+								rel, err := filepath.Rel(rootLocation, wtPath)
+								if err == nil && !strings.HasPrefix(rel, "..") {
+									// Inside
+									wtDir, wtName := dirAndName(rootLocation, wtPath)
+									*paths = append(*paths, RepoData{BaseDir: wtDir, FullName: wtName, Url: gitHttpUrl, Type: repoType})
+								} else {
+									// Outside
+									*paths = append(*paths, RepoData{BaseDir: filepath.Dir(wtPath), FullName: filepath.Base(wtPath), Url: gitHttpUrl, Type: repoType})
+								}
+							}
+						}
+					}
 
 					*paths = addParents(*paths, rootLocation, path)
 					return filepath.SkipDir
@@ -206,6 +230,27 @@ func gitURLToHTTP(url string) string {
 	url = GIT_URL_REGEX.ReplaceAllString(url, "https://${1}/")
 	url = strings.TrimSuffix(url, ".git")
 	return url
+}
+
+func getWorktrees(dir string) ([]string, error) {
+	cmd := exec.Command("git", "worktree", "list", "--porcelain")
+	cmd.Dir = dir
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list worktrees: %v", err)
+	}
+
+	var worktrees []string
+	scanner := bufio.NewScanner(strings.NewReader(string(output)))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(line, "worktree ") {
+			path := strings.TrimPrefix(line, "worktree ")
+			worktrees = append(worktrees, path)
+		}
+	}
+	return worktrees, nil
 }
 
 func repoType(url string) string {

--- a/pkg/repoindex/repo_index_test.go
+++ b/pkg/repoindex/repo_index_test.go
@@ -1,0 +1,130 @@
+package repoindex
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestLocateRepos_Worktrees(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	root1 := filepath.Join(tmpDir, "root1")
+	if err := os.MkdirAll(root1, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	repoDir := filepath.Join(root1, "my-repo")
+	if err := os.MkdirAll(repoDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "config", "user.email", "you@example.com")
+	runGit(t, repoDir, "config", "user.name", "Your Name")
+	runGit(t, repoDir, "commit", "--allow-empty", "-m", "initial commit")
+	runGit(t, repoDir, "remote", "add", "origin", "git@github.com:user/repo.git")
+
+	wtInside := filepath.Join(root1, "wt-inside")
+	runGit(t, repoDir, "worktree", "add", "--detach", wtInside, "master")
+
+	root2 := filepath.Join(tmpDir, "root2")
+	if err := os.MkdirAll(root2, 0755); err != nil {
+		t.Fatal(err)
+	}
+	wtOutside := filepath.Join(root2, "wt-outside")
+	runGit(t, repoDir, "worktree", "add", "--detach", wtOutside, "master")
+
+	repos := locateRepos(root1, make(map[string]struct{}))
+
+	foundRepo := false
+	foundWtInside := false
+	foundWtOutside := false
+
+	for _, r := range repos {
+		if r.FullName == "my-repo" {
+			foundRepo = true
+		}
+		if r.FullName == "wt-inside" {
+			foundWtInside = true
+		}
+		if r.FullName == "wt-outside" {
+			foundWtOutside = true
+		}
+	}
+
+	if !foundRepo {
+		t.Errorf("Expected main repo to be found")
+	}
+	if !foundWtInside {
+		t.Errorf("Expected inside worktree to be found")
+	}
+	if foundWtOutside {
+		// t.Errorf("Did not expect outside worktree to be found (yet)") // Old expectation
+	}
+
+	if !foundWtOutside {
+		t.Errorf("Expected outside worktree to be found")
+	}
+}
+
+func TestGetWorktrees(t *testing.T) {
+	tmpDir := t.TempDir()
+	repoDir := filepath.Join(tmpDir, "repo")
+	os.MkdirAll(repoDir, 0755)
+
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "config", "user.email", "test@test.com")
+	runGit(t, repoDir, "config", "user.name", "Test")
+	runGit(t, repoDir, "commit", "--allow-empty", "-m", "init")
+
+	wt1 := filepath.Join(tmpDir, "wt1")
+	runGit(t, repoDir, "worktree", "add", "--detach", wt1, "master")
+
+	wts, err := getWorktrees(repoDir)
+	if err != nil {
+		t.Fatalf("getWorktrees failed: %v", err)
+	}
+
+	// Expect 2 worktrees: main repo and wt1
+	if len(wts) != 2 {
+		t.Errorf("Expected 2 worktrees, got %d: %v", len(wts), wts)
+	}
+
+	// Check paths
+	foundMain := false
+	foundWt1 := false
+	// resolve symlinks for comparison if needed, but getWorktrees returns as is from git.
+	// Git usually returns absolute paths.
+	// But on Mac /var is /private/var.
+	// We might need to EvalSymlinks.
+
+	repoDirEval, _ := filepath.EvalSymlinks(repoDir)
+	wt1Eval, _ := filepath.EvalSymlinks(wt1)
+
+	for _, w := range wts {
+		wEval, _ := filepath.EvalSymlinks(w)
+		if wEval == repoDirEval {
+			foundMain = true
+		}
+		if wEval == wt1Eval {
+			foundWt1 = true
+		}
+	}
+
+	if !foundMain {
+		t.Errorf("Main repo worktree not found in list: %v", wts)
+	}
+	if !foundWt1 {
+		t.Errorf("Added worktree not found in list: %v", wts)
+	}
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git command %v failed in %s: %v\nOutput: %s", args, dir, err, out)
+	}
+}


### PR DESCRIPTION
When locating a repo - also scan it's worktrees even if outside the search domain

ensure not to create duplicates if the worktrees are in the search domain

make sure not to over-scan - for the same remote only add worktrees once