### PR TITLE
Add one-liner curl installer script (Vibe Kanban)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A CLI tool for indexing all git repos and code projects on your computer
 ### Quick Install (One-liner)
 
 ```bash
-curl -sSL https://raw.githubusercontent.com/your-username/griffin/main/install.sh | sh
+curl -sSL https://raw.githubusercontent.com/ronkitay/griffin/main/install.sh | sh
 ```
 
 This will:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,20 @@ GRIFFIN - **G**it **R**epository **I**ndexer for **F**uzzy **F**inding and **IN*
 
 A CLI tool for indexing all git repos and code projects on your computer
 
+## Installation
+
+### Quick Install (One-liner)
+
+```bash
+curl -sSL https://raw.githubusercontent.com/your-username/griffin/main/install.sh | sh
+```
+
+This will:
+- Download the latest griffin binary for your system
+- Install it to `${HOME}/tools/`
+- Add `${HOME}/tools` to your PATH in `~/.zshrc` (if not already present)
+- Remove the quarantine attribute on macOS
+
 ## Usage
 
 ### Configuring

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,41 @@
+#!/bin/sh
+
+set -e
+
+# Determine OS and architecture
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+
+# Normalize architecture names
+case "$ARCH" in
+  x86_64) ARCH="amd64" ;;
+  aarch64) ARCH="arm64" ;;
+esac
+
+# Create tools directory
+mkdir -p "${HOME}/tools"
+
+# Download and extract the binary
+REPO="your-username/griffin"  # Update with actual repo
+RELEASE_URL="https://github.com/${REPO}/releases/latest/download/griffin-${OS}-${ARCH}"
+
+echo "Downloading griffin for ${OS}/${ARCH}..."
+curl -sL -o "${HOME}/tools/griffin" "$RELEASE_URL"
+chmod +x "${HOME}/tools/griffin"
+
+# Add to PATH in .zshrc if not already present
+ZSHRC="${HOME}/.zshrc"
+if [ -f "$ZSHRC" ]; then
+  if ! grep -q '${HOME}/tools' "$ZSHRC"; then
+    echo 'export PATH="${HOME}/tools:$PATH"' >> "$ZSHRC"
+    echo "Added ${HOME}/tools to PATH in .zshrc"
+  fi
+else
+  echo 'export PATH="${HOME}/tools:$PATH"' > "$ZSHRC"
+  echo "Created .zshrc with ${HOME}/tools in PATH"
+fi
+
+# Remove quarantine attribute (macOS)
+xattr -d com.apple.quarantine "${HOME}/tools/griffin" 2>/dev/null || true
+
+echo "Installation complete! Run 'source ~/.zshrc' or restart your terminal."

--- a/install.sh
+++ b/install.sh
@@ -24,8 +24,15 @@ chmod +x "${HOME}/tools/griffin"
 
 # Add to PATH in .zshrc if not already present
 ZSHRC="${HOME}/.zshrc"
+NEEDS_BACKUP=0
+
 if [ -f "$ZSHRC" ]; then
   if ! grep -q '${HOME}/tools' "$ZSHRC"; then
+    if [ $NEEDS_BACKUP -eq 0 ]; then
+      cp "$ZSHRC" "$ZSHRC.backup"
+      echo "Backed up .zshrc to .zshrc.backup"
+      NEEDS_BACKUP=1
+    fi
     echo 'export PATH="${HOME}/tools:$PATH"' >> "$ZSHRC"
     echo "Added ${HOME}/tools to PATH in .zshrc"
   fi
@@ -36,6 +43,11 @@ fi
 
 # Add shell integration if not already present
 if ! grep -q 'griffin shell-integration' "$ZSHRC"; then
+  if [ $NEEDS_BACKUP -eq 0 ] && [ -f "$ZSHRC" ]; then
+    cp "$ZSHRC" "$ZSHRC.backup"
+    echo "Backed up .zshrc to .zshrc.backup"
+    NEEDS_BACKUP=1
+  fi
   echo 'source <(griffin shell-integration)' >> "$ZSHRC"
   echo "Added griffin shell integration to .zshrc"
 fi

--- a/install.sh
+++ b/install.sh
@@ -34,6 +34,12 @@ else
   echo "Created .zshrc with ${HOME}/tools in PATH"
 fi
 
+# Add shell integration if not already present
+if ! grep -q 'griffin shell-integration' "$ZSHRC"; then
+  echo 'source <(griffin shell-integration)' >> "$ZSHRC"
+  echo "Added griffin shell integration to .zshrc"
+fi
+
 # Remove quarantine attribute (macOS)
 xattr -d com.apple.quarantine "${HOME}/tools/griffin" 2>/dev/null || true
 

--- a/install.sh
+++ b/install.sh
@@ -16,8 +16,7 @@ esac
 mkdir -p "${HOME}/tools"
 
 # Download and extract the binary
-REPO="your-username/griffin"  # Update with actual repo
-RELEASE_URL="https://github.com/${REPO}/releases/latest/download/griffin-${OS}-${ARCH}"
+RELEASE_URL="https://github.com/ronkitay/griffin/releases/latest/download/griffin-${OS}-${ARCH}"
 
 echo "Downloading griffin for ${OS}/${ARCH}..."
 curl -sL -o "${HOME}/tools/griffin" "$RELEASE_URL"

--- a/install.sh
+++ b/install.sh
@@ -22,34 +22,35 @@ echo "Downloading griffin for ${OS}/${ARCH}..."
 curl -sL -o "${HOME}/tools/griffin" "$RELEASE_URL"
 chmod +x "${HOME}/tools/griffin"
 
-# Add to PATH in .zshrc if not already present
+# Check what needs to be added to .zshrc
 ZSHRC="${HOME}/.zshrc"
-NEEDS_BACKUP=0
+NEED_PATH=false
+NEED_INTEGRATION=false
 
-if [ -f "$ZSHRC" ]; then
-  if ! grep -q '${HOME}/tools' "$ZSHRC"; then
-    if [ $NEEDS_BACKUP -eq 0 ]; then
-      cp "$ZSHRC" "$ZSHRC.backup"
-      echo "Backed up .zshrc to .zshrc.backup"
-      NEEDS_BACKUP=1
-    fi
+if [ ! -f "$ZSHRC" ] || ! grep -q '${HOME}/tools' "$ZSHRC"; then
+  NEED_PATH=true
+fi
+
+if [ ! -f "$ZSHRC" ] || ! grep -q 'griffin shell-integration' "$ZSHRC"; then
+  NEED_INTEGRATION=true
+fi
+
+# If any changes are needed, back up the file first
+if [ "$NEED_PATH" = true ] || [ "$NEED_INTEGRATION" = true ]; then
+  if [ -f "$ZSHRC" ]; then
+    cp "$ZSHRC" "$ZSHRC.griffin-backup"
+    echo "Backed up .zshrc to .zshrc.griffin-backup"
+  fi
+  
+  if [ "$NEED_PATH" = true ]; then
     echo 'export PATH="${HOME}/tools:$PATH"' >> "$ZSHRC"
     echo "Added ${HOME}/tools to PATH in .zshrc"
   fi
-else
-  echo 'export PATH="${HOME}/tools:$PATH"' > "$ZSHRC"
-  echo "Created .zshrc with ${HOME}/tools in PATH"
-fi
-
-# Add shell integration if not already present
-if ! grep -q 'griffin shell-integration' "$ZSHRC"; then
-  if [ $NEEDS_BACKUP -eq 0 ] && [ -f "$ZSHRC" ]; then
-    cp "$ZSHRC" "$ZSHRC.backup"
-    echo "Backed up .zshrc to .zshrc.backup"
-    NEEDS_BACKUP=1
+  
+  if [ "$NEED_INTEGRATION" = true ]; then
+    echo 'source <(griffin shell-integration)' >> "$ZSHRC"
+    echo "Added griffin shell integration to .zshrc"
   fi
-  echo 'source <(griffin shell-integration)' >> "$ZSHRC"
-  echo "Added griffin shell integration to .zshrc"
 fi
 
 # Remove quarantine attribute (macOS)


### PR DESCRIPTION
## Summary
This PR introduces a convenient one-liner installer for griffin, making it easy for users to download and install the tool directly from the command line.

## Changes Made

### New Files
- **install.sh**: A comprehensive installation script that:
  - Auto-detects the OS (macOS, Linux) and architecture (x86_64, ARM64)
  - Downloads the latest binary from GitHub releases
  - Installs to `${HOME}/tools/`
  - Automatically configures the shell environment

### README Updates
- Added **Installation** section with quick-start one-liner
- Users can now install griffin with: `curl -sSL https://raw.githubusercontent.com/ronkitay/griffin/main/install.sh | sh`

## Implementation Details

The installer script:
1. **Auto-detection**: Uses `uname` to detect OS and architecture, normalizing architecture names (x86_64 → amd64, aarch64 → arm64)
2. **Smart PATH Configuration**: Only adds `${HOME}/tools` to PATH if not already present
3. **Shell Integration**: Automatically enables griffin's shell integration via `source <(griffin shell-integration)`
4. **Safety**: Creates a backup of `.zshrc` as `.zshrc.griffin-backup` before making any modifications
5. **macOS Support**: Removes quarantine attribute using `xattr` to ensure the binary runs without warnings on macOS

## Testing
- Installer works for both new and existing `.zshrc` files
- PATH and shell integration are only added once (idempotent)
- Backup is created before any modifications to user's shell configuration

---
This PR was written using [Vibe Kanban](https://vibekanban.com)