### PR TITLE
Create release script with semantic versioning support (Vibe Kanban)

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Default values
+MODE=""
+APPLY=false
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --major)
+      MODE="major"
+      shift
+      ;;
+    --minor)
+      MODE="minor"
+      shift
+      ;;
+    --patch)
+      MODE="patch"
+      shift
+      ;;
+    --apply)
+      APPLY=true
+      shift
+      ;;
+    *)
+      echo "Error: Unknown option '$1'"
+      echo ""
+      echo "Usage: $0 (--major | --minor | --patch) [--apply]"
+      exit 1
+      ;;
+  esac
+done
+
+# Validate that a mode was selected
+if [[ -z "$MODE" ]]; then
+  echo "Error: Must specify one of --major, --minor, or --patch"
+  echo ""
+  echo "Usage: $0 (--major | --minor | --patch) [--apply]"
+  exit 1
+fi
+
+# Get the latest tag
+LATEST_TAG=$(git tag -l | sort -V | tail -n 1)
+
+if [[ -z "$LATEST_TAG" ]]; then
+  echo "Error: No existing tags found"
+  exit 1
+fi
+
+# Parse the current version (remove 'v' prefix if present)
+CURRENT_VERSION="${LATEST_TAG#v}"
+IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_VERSION"
+
+# Calculate new version based on mode
+case $MODE in
+  major)
+    MAJOR=$((MAJOR + 1))
+    MINOR=0
+    PATCH=0
+    ;;
+  minor)
+    MINOR=$((MINOR + 1))
+    PATCH=0
+    ;;
+  patch)
+    PATCH=$((PATCH + 1))
+    ;;
+esac
+
+NEW_VERSION="$MAJOR.$MINOR.$PATCH"
+NEW_TAG="v$NEW_VERSION"
+
+echo "Current version: $LATEST_TAG"
+echo "New version:    $NEW_TAG"
+
+if [[ "$APPLY" == true ]]; then
+  echo ""
+  echo "Pushing tag $NEW_TAG..."
+  git tag "$NEW_TAG"
+  git push origin "$NEW_TAG"
+  echo "✓ Release $NEW_TAG pushed successfully"
+else
+  echo ""
+  echo "Run with --apply to push this release"
+fi

--- a/release.sh
+++ b/release.sh
@@ -6,57 +6,70 @@ set -euo pipefail
 MODE=""
 APPLY=false
 
-# Parse arguments
-while [[ $# -gt 0 ]]; do
-  case $1 in
-    --major)
+# Convert long options to short options
+for arg in "$@"; do
+  shift
+  case "$arg" in
+    '--major')  set -- "$@" '-M' ;;
+    '--minor')  set -- "$@" '-m' ;;
+    '--patch')  set -- "$@" '-p' ;;
+    '--apply')  set -- "$@" '-a' ;;
+    '--help')   set -- "$@" '-h' ;;
+    *)          set -- "$@" "$arg" ;;
+  esac
+done
+
+# Parse options using getopts
+while getopts ":Mmpha" option; do
+  case "${option}" in
+    M)
       if [[ -n "$MODE" ]]; then
-        echo "Error: Cannot specify multiple modes (--major, --minor, --patch)"
-        echo ""
-        echo "Usage: $0 (--major | --minor | --patch) [--apply]"
+        echo "Error: Cannot specify multiple modes (-M, -m, -p / --major, --minor, --patch)"
         exit 1
       fi
       MODE="major"
-      shift
       ;;
-    --minor)
+    m)
       if [[ -n "$MODE" ]]; then
-        echo "Error: Cannot specify multiple modes (--major, --minor, --patch)"
-        echo ""
-        echo "Usage: $0 (--major | --minor | --patch) [--apply]"
+        echo "Error: Cannot specify multiple modes (-M, -m, -p / --major, --minor, --patch)"
         exit 1
       fi
       MODE="minor"
-      shift
       ;;
-    --patch)
+    p)
       if [[ -n "$MODE" ]]; then
-        echo "Error: Cannot specify multiple modes (--major, --minor, --patch)"
-        echo ""
-        echo "Usage: $0 (--major | --minor | --patch) [--apply]"
+        echo "Error: Cannot specify multiple modes (-M, -m, -p / --major, --minor, --patch)"
         exit 1
       fi
       MODE="patch"
-      shift
       ;;
-    --apply)
+    a)
       APPLY=true
-      shift
+      ;;
+    h)
+      echo "Usage: $0 (-M | -m | -p | --major | --minor | --patch) [-a | --apply]"
+      echo ""
+      echo "Options:"
+      echo "  -M, --major   Bump major version"
+      echo "  -m, --minor   Bump minor version"
+      echo "  -p, --patch   Bump patch version"
+      echo "  -a, --apply   Actually push the tag (default: dry-run)"
+      echo "  -h, --help    Show this help message"
+      exit 0
       ;;
     *)
-      echo "Error: Unknown option '$1'"
-      echo ""
-      echo "Usage: $0 (--major | --minor | --patch) [--apply]"
+      echo "Error: Invalid option '$OPTARG'"
+      echo "Usage: $0 (-M | -m | -p | --major | --minor | --patch) [-a | --apply]"
       exit 1
       ;;
   esac
 done
+shift $((OPTIND - 1))
 
 # Validate that a mode was selected
 if [[ -z "$MODE" ]]; then
-  echo "Error: Must specify one of --major, --minor, or --patch"
-  echo ""
-  echo "Usage: $0 (--major | --minor | --patch) [--apply]"
+  echo "Error: Must specify one of -M, -m, -p (or --major, --minor, --patch)"
+  echo "Usage: $0 (-M | -m | -p | --major | --minor | --patch) [-a | --apply]"
   exit 1
 fi
 

--- a/release.sh
+++ b/release.sh
@@ -10,14 +10,32 @@ APPLY=false
 while [[ $# -gt 0 ]]; do
   case $1 in
     --major)
+      if [[ -n "$MODE" ]]; then
+        echo "Error: Cannot specify multiple modes (--major, --minor, --patch)"
+        echo ""
+        echo "Usage: $0 (--major | --minor | --patch) [--apply]"
+        exit 1
+      fi
       MODE="major"
       shift
       ;;
     --minor)
+      if [[ -n "$MODE" ]]; then
+        echo "Error: Cannot specify multiple modes (--major, --minor, --patch)"
+        echo ""
+        echo "Usage: $0 (--major | --minor | --patch) [--apply]"
+        exit 1
+      fi
       MODE="minor"
       shift
       ;;
     --patch)
+      if [[ -n "$MODE" ]]; then
+        echo "Error: Cannot specify multiple modes (--major, --minor, --patch)"
+        echo ""
+        echo "Usage: $0 (--major | --minor | --patch) [--apply]"
+        exit 1
+      fi
       MODE="patch"
       shift
       ;;


### PR DESCRIPTION
## Overview
This PR implements a production-ready release script that automates semantic versioning and Git tag management.

## What Changed
- **New file**: `release.sh` - A bash script for managing semantic version releases

## Implementation Details

### Features
- **Three release modes**: Major (-M/--major), Minor (-m/--minor), Patch (-p/--patch)
- **Semantic versioning**: Automatically calculates and applies SemVer bumps based on the last Git tag
- **Dry-run by default**: Calculates and displays the new version without making changes
- **Safe release mode**: Optional `-a`/`--apply` flag to actually push the tag
- **Mutual exclusivity validation**: Prevents users from specifying multiple modes simultaneously
- **Robust argument parsing**: Uses `getopts` for clean, idiomatic bash option handling
- **Both long and short options**: Supports `--major`/`-M`, `--minor`/`-m`, `--patch`/`-p`, `--apply`/`-a`
- **Help documentation**: `-h`/`--help` flag for usage information

### Version Bump Examples (from v0.0.7)
- `./release.sh --major` → v1.0.0
- `./release.sh --minor` → v0.1.0
- `./release.sh --patch` → v0.0.8

### Usage
```bash
# Dry-run (just show what would happen)
./release.sh --patch

# Actually create and push the tag
./release.sh --patch --apply

# Short form
./release.sh -p -a

# Show help
./release.sh --help
```

## Why These Changes
The script provides a safe, repeatable way to manage releases:
- **Safety first**: Default dry-run prevents accidental releases
- **Clarity**: Clear error messages for invalid inputs
- **Flexibility**: Support for both long and short option forms
- **Maintainability**: Uses standard bash practices for readability and reliability

This PR was written using [Vibe Kanban](https://vibekanban.com)