### PR TITLE
Shorten long paths in Alfred output (Vibe Kanban)

### DIFF
--- a/pkg/alfred/alfred.go
+++ b/pkg/alfred/alfred.go
@@ -10,6 +10,17 @@ import (
 	repo "ronkitay.com/griffin/pkg/repoindex"
 )
 
+func shortenPath(path string) string {
+	const maxLen = 53
+	const halfLen = 25
+	
+	if len(path) <= maxLen {
+		return path
+	}
+	
+	return path[:halfLen] + "..." + path[len(path)-halfLen:]
+}
+
 func ReposAsAlfred(matchingRepos []repo.RepoData) string {
 	var items []Item
 
@@ -51,7 +62,7 @@ func buildDirectoryLocation(repoDir string, repoName string) Item {
 		Valid:    true,
 		UID:      repoName,
 		Title:    repoName,
-		Subtitle: "Open in TERMINAL (🖥️) : " + repoDir,
+		Subtitle: "Open in TERMINAL (🖥️) : " + shortenPath(repoDir),
 		Arg:      repoDir,
 		Icon: Icon{
 			Path: "icons/dir.jpg",
@@ -64,7 +75,7 @@ func buildArchiveLocation(repoDir string, repoName string, url string) Item {
 		Valid:    true,
 		UID:      repoName,
 		Title:    repoName,
-		Subtitle: "Open in TERMINAL (🖥️) : " + repoDir,
+		Subtitle: "Open in TERMINAL (🖥️) : " + shortenPath(repoDir),
 		Arg:      repoDir,
 		Mods: map[string]Modifier{
 			"alt": {
@@ -80,11 +91,12 @@ func buildArchiveLocation(repoDir string, repoName string, url string) Item {
 }
 
 func buildGitRepoLocation(repoDir string, repoName string, url string, locationType string) Item {
+	shortenedPath := shortenPath(repoDir)
 	return Item{
 		Valid:    true,
 		UID:      repoName,
 		Title:    repoName,
-		Subtitle: "Open in TERMINAL (🖥️) : " + repoDir,
+		Subtitle: "Open in TERMINAL (🖥️) : " + shortenedPath,
 		Arg:      repoDir,
 		Mods: map[string]Modifier{
 			"alt": {
@@ -95,12 +107,12 @@ func buildGitRepoLocation(repoDir string, repoName string, url string, locationT
 			"ctrl": {
 				Valid:    true,
 				Arg:      repoDir,
-				Subtitle: "Open in EDITOR (📝): " + repoDir,
+				Subtitle: "Open in EDITOR (📝): " + shortenedPath,
 			},
 			"ctrl+shift": {
 				Valid:    true,
 				Arg:      repoDir,
-				Subtitle: "Open in ALTERNATIVE EDITOR (🛠️): " + repoDir,
+				Subtitle: "Open in ALTERNATIVE EDITOR (🛠️): " + shortenedPath,
 			},
 		},
 		Icon: Icon{
@@ -131,23 +143,24 @@ func ProjectsAsAlfred(matchingProjects []projectIndex.ProjectData) string {
 
 func buildAlfredItemForProject(project projectIndex.ProjectData) Item {
 	projectFullPath := filepath.Join(project.BaseDir, project.FullName)
+	shortenedPath := shortenPath(projectFullPath)
 
 	return Item{
 		Valid:    true,
 		UID:      project.FullName,
 		Title:    project.FullName,
-		Subtitle: "Open in TERMINAL (🖥️) : " + projectFullPath,
+		Subtitle: "Open in TERMINAL (🖥️) : " + shortenedPath,
 		Arg:      projectFullPath,
 		Mods: map[string]Modifier{
 			"ctrl": {
 				Valid:    true,
 				Arg:      projectFullPath,
-				Subtitle: "Open in EDITOR (📝): " + projectFullPath,
+				Subtitle: "Open in EDITOR (📝): " + shortenedPath,
 			},
 			"ctrl+shift": {
 				Valid:    true,
 				Arg:      projectFullPath,
-				Subtitle: "Open in ALTERNATIVE EDITOR (🛠️): " + projectFullPath,
+				Subtitle: "Open in ALTERNATIVE EDITOR (🛠️): " + shortenedPath,
 			},
 		},
 		Icon: Icon{


### PR DESCRIPTION
## Summary
Implemented path shortening for Alfred workflow output to improve readability when displaying long file system paths.

## Changes Made
- **Added `shortenPath()` function** in `pkg/alfred/alfred.go` that truncates paths longer than 53 characters
  - Format: `<first 25 chars>...<last 25 chars>`
  - Paths ≤53 characters are displayed unchanged
  - Longer paths are truncated to exactly 53 characters
  
- **Updated all Alfred item path displays** to use path shortening:
  - Directory locations (Terminal subtitle)
  - Archive locations (Terminal subtitle)
  - Git repository locations (Terminal, Editor, and Alternative Editor subtitles)
  - Project locations (Terminal, Editor, and Alternative Editor subtitles)

## Why This Change
Long file system paths can exceed the display width available in Alfred's workflow results, making the interface unwieldy. By intelligently shortening paths while preserving both the start (parent directories) and end (file/folder name), users get useful context while maintaining a clean UI.

## Implementation Details
- The function preserves the full path in the item's `arg` field (used for actual operations)
- Only the `subtitle` field (display text) shows the shortened path
- The "..." ellipsis clearly indicates when a path has been truncated
- Consistent application across all repo and project display modes

## Testing
- Code builds successfully with `go build ./...`
- Path shortening logic verified with multiple test cases
- Paths at exactly 53 characters remain unchanged
- Paths over 53 characters are shortened to exactly 53 characters using the first 25 + last 25 format

---
This PR was written using [Vibe Kanban](https://vibekanban.com)
