### PR TITLE
Add --version flag support (Vibe Kanban)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,6 +16,7 @@ builds:
     ldflags:
       - -s
       - -w
+      - -X ronkitay.com/griffin/pkg/version.Version={{.Version}}
     env:
       - CGO_ENABLED=0
     goos:

--- a/build.sh
+++ b/build.sh
@@ -1,3 +1,4 @@
 #!/bin/sh
 
-go build -trimpath -ldflags "-s -w" -o out/griffin cmd/griffin/main.go && cp out/griffin ${HOME}/tools/
+VERSION=$(git describe --tags --always 2>/dev/null || echo "dev")
+go build -trimpath -ldflags "-s -w -X ronkitay.com/griffin/pkg/version.Version=${VERSION}" -o out/griffin cmd/griffin/main.go && cp out/griffin ${HOME}/tools/

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -12,6 +12,7 @@ import (
 	"ronkitay.com/griffin/pkg/repoindex"
 	"ronkitay.com/griffin/pkg/shell"
 	"ronkitay.com/griffin/pkg/terminal"
+	"ronkitay.com/griffin/pkg/version"
 )
 
 type CommandHandler func(*Command, string)
@@ -44,6 +45,8 @@ func Run() {
 
 	if userRequestsHelp(commandName) {
 		printToolHelp(executableName)
+	} else if userRequestsVersion(commandName) {
+		printVersion()
 	} else {
 		command := matchCommand(commandName)
 		if command != nil {
@@ -57,6 +60,15 @@ func Run() {
 
 func userRequestsHelp(commandName string) bool {
 	return commandName == "-h" || commandName == "--help" || commandName == "help"
+}
+
+func userRequestsVersion(commandName string) bool {
+	return commandName == "-v" || commandName == "--version" || commandName == "version"
+}
+
+func printVersion() {
+	fmt.Printf("griffin version %s\n", version.Version)
+	os.Exit(0)
 }
 
 func printToolHelp(executableName string) {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,3 @@
+package version
+
+var Version = "dev"


### PR DESCRIPTION
## Summary
Add support for a `--version` flag that displays the version tag associated with the built binary.

## Changes Made
- **New `pkg/version` package**: Created a version package with a `Version` variable that defaults to "dev" and can be injected at build time
- **CLI version flag handling**: Updated `pkg/cli/cli.go` to recognize three forms of version requests:
  - `-v` (short form)
  - `--version` (long form)
  - `version` (command form)
- **Build-time version injection**: Updated `build.sh` to capture the current git tag using `git describe --tags --always` and inject it via Go's ldflags (`-X`)
- **Release configuration**: Updated `.goreleaser.yaml` to inject the version tag during official releases

## Why
Users need to quickly identify which version of the griffin tool they're running, especially when deployed across multiple systems. The version is captured from git tags, ensuring it always reflects the exact release version.

## Implementation Details
- Version information is injected at compile time using Go's ldflags mechanism: `-X ronkitay.com/griffin/pkg/version.Version=<version>`
- When no git tag is available (e.g., dev builds), the version defaults to "dev"
- The feature supports both local builds (via `build.sh`) and official releases (via `goreleaser`)
- All three flag forms exit cleanly after printing the version

## Testing
- `./out/griffin -v` → `griffin version v0.0.12`
- `./out/griffin --version` → `griffin version v0.0.12`
- `./out/griffin version` → `griffin version v0.0.12`

---
This PR was written using [Vibe Kanban](https://vibekanban.com)
