### PR TITLE
Fix worktree duplication when located under configured directories (Vibe Kanban)

### DIFF
--- a/pkg/repoindex/repo-index.go
+++ b/pkg/repoindex/repo-index.go
@@ -180,12 +180,24 @@ func visit(rootLocation string, paths *[]RepoData, processedRemotes map[string]s
 }
 
 func deDuplicate(input []RepoData) []RepoData {
-	encountered := map[RepoData]bool{}
+	// Use a key of BaseDir + FullName to detect duplicates
+	// Prefer entries with aliases (worktrees) over entries without
+	encountered := make(map[string]int) // maps key to index in result
 	result := []RepoData{}
 
-	for _, v := range input {
-		if !encountered[v] {
-			encountered[v] = true
+	for i, v := range input {
+		// Use absolute path after evaluating symlinks to normalize paths
+		absBase, _ := filepath.EvalSymlinks(v.BaseDir)
+		key := filepath.Join(absBase, v.FullName)
+
+		if existingIdx, found := encountered[key]; found {
+			// If the new entry has an alias and the existing one doesn't,
+			// replace the existing one (prefer worktree version)
+			if v.Alias != "" && result[existingIdx].Alias == "" {
+				result[existingIdx] = input[i]
+			}
+		} else {
+			encountered[key] = len(result)
 			result = append(result, v)
 		}
 	}

--- a/pkg/repoindex/repo_index_test.go
+++ b/pkg/repoindex/repo_index_test.go
@@ -41,6 +41,7 @@ func TestLocateRepos_Worktrees(t *testing.T) {
 	foundRepo := false
 	foundWtInside := false
 	foundWtOutside := false
+	wtInsideCount := 0
 
 	for _, r := range repos {
 		if r.FullName == "my-repo" {
@@ -48,6 +49,7 @@ func TestLocateRepos_Worktrees(t *testing.T) {
 		}
 		if r.FullName == "wt-inside" {
 			foundWtInside = true
+			wtInsideCount++
 		}
 		if r.FullName == "my-repo" {
 			foundWtOutside = true
@@ -60,12 +62,68 @@ func TestLocateRepos_Worktrees(t *testing.T) {
 	if !foundWtInside {
 		t.Errorf("Expected inside worktree to be found")
 	}
+	if wtInsideCount > 1 {
+		t.Errorf("Expected worktree 'wt-inside' to appear only once, but found %d times", wtInsideCount)
+	}
 	if foundWtOutside {
 		// t.Errorf("Did not expect outside worktree to be found (yet)") // Old expectation
 	}
 
 	if !foundWtOutside {
 		t.Errorf("Expected outside worktree to be found")
+	}
+}
+
+func TestLocateRepos_WorktreeNoDuplication(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a directory structure similar to the bug report
+	root := filepath.Join(tmpDir, "code/personal")
+	if err := os.MkdirAll(root, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create main repo
+	repoDir := filepath.Join(root, "griffin")
+	if err := os.MkdirAll(repoDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "config", "user.email", "test@test.com")
+	runGit(t, repoDir, "config", "user.name", "Test")
+	runGit(t, repoDir, "commit", "--allow-empty", "-m", "init")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/ronkitay/griffin")
+
+	// Create a worktree under the same configured directory (this is the bug scenario)
+	wtDir := filepath.Join(root, "griffin-test")
+	runGit(t, repoDir, "worktree", "add", "--detach", wtDir, "master")
+
+	// Locate repos starting from the configured root
+	repos := locateRepos(root, make(map[string]struct{}))
+
+	// Count how many times the worktree appears and check it has the alias
+	wtCount := 0
+	wtWithAlias := false
+	rootEval, _ := filepath.EvalSymlinks(root)
+
+	for _, r := range repos {
+		rBaseEval, _ := filepath.EvalSymlinks(r.BaseDir)
+		if rBaseEval == rootEval && r.FullName == "griffin-test" {
+			wtCount++
+			if r.Alias == "griffin" {
+				wtWithAlias = true
+			}
+		}
+	}
+
+	if wtCount != 1 {
+		t.Errorf("Expected worktree 'griffin-test' to appear exactly once, but found %d times", wtCount)
+		t.Logf("All repos: %+v", repos)
+	}
+	if !wtWithAlias {
+		t.Errorf("Expected worktree to have alias 'griffin'")
+		t.Logf("All repos: %+v", repos)
 	}
 }
 
@@ -106,9 +164,11 @@ func TestLocateRepos_Dev3Worktrees(t *testing.T) {
 	// Find the main repo
 	var foundMain, foundWt bool
 	var wtFullName, wtBaseDir string
+	rootEval, _ := filepath.EvalSymlinks(root)
 
 	for _, r := range repos {
-		if r.FullName == "my-repo" && r.BaseDir == root {
+		rBaseEval, _ := filepath.EvalSymlinks(r.BaseDir)
+		if r.FullName == "my-repo" && rBaseEval == rootEval {
 			foundMain = true
 		}
 		if r.FullName == "worktree" {
@@ -124,6 +184,7 @@ func TestLocateRepos_Dev3Worktrees(t *testing.T) {
 
 	if !foundMain {
 		t.Errorf("Expected main repo to be found")
+		t.Logf("Found repos: %+v", repos)
 	}
 	if !foundWt {
 		t.Errorf("Expected worktree to be found")


### PR DESCRIPTION
## Problem

When a worktree is located under a configured directory (e.g., `/Users/ronk/code/personal`), it appears twice in the repo index:
1. Once as a worktree (with alias = main repo name)
2. Once as a regular repository (with no alias)

This causes duplicate entries in the repository list, confusing users who expect only one entry per worktree.

## Root Cause

The `deDuplicate()` function in `repo-index.go` was comparing entire `RepoData` structs for equality. When the same worktree was discovered through two different paths:
- Once during directory walking (as a regular repo, no alias)
- Once through the worktree enumeration (with alias set to main repo name)

These entries had different values for the `Alias` field, so they weren't considered duplicates and both were kept.

## Solution

Updated the deduplication logic to:

1. **Use path-based keys**: Instead of comparing full `RepoData` structs, use `BaseDir + FullName` as the deduplication key to identify the same repository/worktree
2. **Normalize paths**: Evaluate symlinks before creating deduplication keys to handle platform differences (e.g., macOS's `/var` → `/private/var` symlink)
3. **Prefer worktree versions**: When duplicates are detected, keep the entry with an alias (the worktree version) and discard the one without (the regular repo version)

## Changes Made

- **`pkg/repoindex/repo-index.go`**: Completely rewrote the `deDuplicate()` function to use a path-based deduplication strategy with symlink normalization
- **`pkg/repoindex/repo_index_test.go`**: 
  - Added new test `TestLocateRepos_WorktreeNoDuplication()` to specifically test the bug scenario
  - Enhanced `TestLocateRepos_Worktrees()` to verify worktrees only appear once
  - Updated `TestLocateRepos_Dev3Worktrees()` to handle symlink path comparisons

## Testing

✅ All 5 existing and new tests pass:
- `TestLocateRepos_Worktrees`
- `TestLocateRepos_WorktreeNoDuplication` (new)
- `TestLocateRepos_Dev3Worktrees`
- `TestMatchingWorktrees`
- `TestGetWorktrees`

---

This PR was written using [Vibe Kanban](https://vibekanban.com)