### PR TITLE
Duplicate entries when worktree is in search path (vibe-kanban)

### DIFF
--- a/pkg/projectindex/project-index.go
+++ b/pkg/projectindex/project-index.go
@@ -55,7 +55,30 @@ func BuildProjectIndex() {
 		scanRepoForProjects(repoRoot, &projects)
 	}
 
+	projects = deDuplicateProjects(projects)
+
 	csvHelper.SaveIndex(config.LoadConfiguration().ProjectListLocation, projects)
+}
+
+func deDuplicateProjects(input []ProjectData) []ProjectData {
+	encountered := make(map[string]struct{})
+	result := []ProjectData{}
+
+	for _, v := range input {
+		fullPath := filepath.Join(v.BaseDir, v.FullName)
+		absPath, err := filepath.EvalSymlinks(fullPath)
+		if err != nil {
+			absPath = filepath.Clean(fullPath)
+		}
+		key := absPath
+
+		if _, found := encountered[key]; !found {
+			encountered[key] = struct{}{}
+			result = append(result, v)
+		}
+	}
+
+	return result
 }
 
 func scanRepoForProjects(rootLocation string, projects *[]ProjectData) {
@@ -134,9 +157,11 @@ func matchedProgrammingLanguage(path string) (string, error) {
 }
 
 func dirAndName(rootLocation string, path string) (string, string) {
+	rootLocation = filepath.Clean(rootLocation)
+	path = filepath.Clean(path)
 	if path == rootLocation {
 		return filepath.Dir(path), filepath.Base(path)
 	} else {
-		return rootLocation, strings.Replace(path, rootLocation+"/", "", -1)
+		return rootLocation, strings.TrimPrefix(strings.TrimPrefix(path, rootLocation), string(filepath.Separator))
 	}
 }

--- a/pkg/repoindex/repo-index.go
+++ b/pkg/repoindex/repo-index.go
@@ -91,6 +91,8 @@ func BuildRepoIndex() error {
 		repos = append(repos, reposFromRoot...)
 	}
 
+	repos = deDuplicate(repos)
+
 	if err := csvHelper.SaveIndex(configuration.RepoListLocation, repos); err != nil {
 		return fmt.Errorf("error saving repo index: %v", err)
 	}
@@ -180,21 +182,26 @@ func visit(rootLocation string, paths *[]RepoData, processedRemotes map[string]s
 }
 
 func deDuplicate(input []RepoData) []RepoData {
-	// Use a key of BaseDir + FullName to detect duplicates
+	// Use a key of the full absolute path after evaluating symlinks to detect duplicates
 	// Prefer entries with aliases (worktrees) over entries without
 	encountered := make(map[string]int) // maps key to index in result
 	result := []RepoData{}
 
-	for i, v := range input {
+	for _, v := range input {
 		// Use absolute path after evaluating symlinks to normalize paths
-		absBase, _ := filepath.EvalSymlinks(v.BaseDir)
-		key := filepath.Join(absBase, v.FullName)
+		fullPath := filepath.Join(v.BaseDir, v.FullName)
+		absPath, err := filepath.EvalSymlinks(fullPath)
+		if err != nil {
+			absPath = filepath.Clean(fullPath)
+		}
+		key := absPath
 
 		if existingIdx, found := encountered[key]; found {
-			// If the new entry has an alias and the existing one doesn't,
-			// replace the existing one (prefer worktree version)
-			if v.Alias != "" && result[existingIdx].Alias == "" {
-				result[existingIdx] = input[i]
+			existing := result[existingIdx]
+			// Prefer entries with aliases (worktrees) over entries without.
+			// Also prefer real repositories over plain directories.
+			if (v.Alias != "" && existing.Alias == "") || (v.Type != "dir" && existing.Type == "dir") {
+				result[existingIdx] = v
 			}
 		} else {
 			encountered[key] = len(result)
@@ -218,10 +225,12 @@ func addParents(repos []RepoData, rootLocation, path string) []RepoData {
 }
 
 func dirAndName(rootLocation string, path string) (string, string) {
+	rootLocation = filepath.Clean(rootLocation)
+	path = filepath.Clean(path)
 	if path == rootLocation {
 		return filepath.Dir(path), filepath.Base(path)
 	} else {
-		return rootLocation, strings.Replace(path, rootLocation+"/", "", -1)
+		return rootLocation, strings.TrimPrefix(strings.TrimPrefix(path, rootLocation), string(filepath.Separator))
 	}
 }
 

--- a/pkg/repoindex/repo_index_test.go
+++ b/pkg/repoindex/repo_index_test.go
@@ -313,6 +313,52 @@ func TestGetWorktrees(t *testing.T) {
 	}
 }
 
+func TestLocateRepos_SymlinkedDuplicate(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	realDir := filepath.Join(tmpDir, "real")
+	if err := os.MkdirAll(realDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	repoDir := filepath.Join(realDir, "repo")
+	if err := os.MkdirAll(repoDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	runGit(t, repoDir, "init")
+	runGit(t, repoDir, "config", "user.email", "test@test.com")
+	runGit(t, repoDir, "config", "user.name", "Test")
+	runGit(t, repoDir, "commit", "--allow-empty", "-m", "init")
+	runGit(t, repoDir, "remote", "add", "origin", "https://github.com/ronkitay/griffin")
+
+	symDir := filepath.Join(tmpDir, "sym")
+	if err := os.Symlink(realDir, symDir); err != nil {
+		t.Fatal(err)
+	}
+
+	// Scan both real and symlinked directories
+	repos := locateRepos(realDir, make(map[string]struct{}))
+	repos = append(repos, locateRepos(symDir, make(map[string]struct{}))...)
+
+	// Deduplicate them as BuildRepoIndex would do
+	repos = deDuplicate(repos)
+
+	repoCount := 0
+	for _, r := range repos {
+		if r.FullName == "repo" {
+			repoCount++
+		}
+	}
+
+	if repoCount != 1 {
+		t.Errorf("Expected repo to appear exactly once, but found %d times", repoCount)
+		for _, r := range repos {
+			t.Logf("Repo: %+v", r)
+		}
+	}
+}
+
 func runGit(t *testing.T, dir string, args ...string) {
 	cmd := exec.Command("git", args...)
 	cmd.Dir = dir


### PR DESCRIPTION
see for example `/Users/ronk/code/personal/griffin-test` which appears twice right now